### PR TITLE
Add headers in install

### DIFF
--- a/libkopete/CMakeLists.txt
+++ b/libkopete/CMakeLists.txt
@@ -277,6 +277,8 @@ install( FILES
   kopeteutils.h
   kopeteversion.h
   kopetestatusmanager.h
+  libkopete_debug.h
+  kopete_export.h
   tasks/kopetetask.h
   tasks/kopetecontacttaskbase.h
   tasks/kopetedeletecontacttask.h


### PR DESCRIPTION
This files are included from some of Kopete's headers so without them it is impossible to build plugins