### PR TITLE
Local path is not yet URL

### DIFF
--- a/libkopete/kopeteavatarmanager.cpp
+++ b/libkopete/kopeteavatarmanager.cpp
@@ -87,7 +87,7 @@ AvatarManager::AvatarManager(QObject *parent)
  : QObject(parent), d(new Private)
 {
 	// Locate avatar data dir on disk
-	d->baseDir = QUrl( QStandardPaths::writableLocation(QStandardPaths::DataLocation) + QLatin1String("/avatars") ) ;
+	d->baseDir = QUrl::fromLocalFile( QStandardPaths::writableLocation(QStandardPaths::DataLocation) + QLatin1String("/avatars") ) ;
 
 	// Create directory on disk, if necessary
 	d->createDirectory( d->baseDir );


### PR DESCRIPTION
QStandardPaths::writableLocation() return local path hence when you pass it into QUrl() constructor it became an invalid URL.